### PR TITLE
docs: add doxygen to docusaurus website

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -28,6 +28,11 @@ module.exports = {
           position: "left",
         },
         {
+          to: "doxygen/", // part of the static folder, run doxygen first
+          label: "Doxygen C API",
+          position: "left",
+        },
+        {
           // WARNING, if you change routeBasePath of docs, you should change this as well
           to: "docs/about",
           label: "About",

--- a/docusaurus/src/pages/doxygen.js
+++ b/docusaurus/src/pages/doxygen.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Layout from "@theme/Layout";
+
+/**
+ * An iframe showing the static docusaraurus docs.
+ *
+ * @returns {React.ReactElement} The iframe to render.
+ */
+function DoxygenIframe() {
+  return (
+    <Layout
+      title={"C API (Doxygen)"}
+      description="Doxygen generated documentation for the EDGESec C API"
+    >
+      <iframe src="https://nqminds.github.io/edgesec" width="100%" style={{height: "90vh"}} />
+    </Layout>
+  );
+}
+
+export default DoxygenIframe;


### PR DESCRIPTION
Embeds an iframe of https://nqminds.github.io/edgesec in the https://edgesec.info/doxygen URL.

I've tried to get the `iframe` to automatically expand, so that we don't need to always see the scrollbar, but no luck unfortunately, CSS is still incomprehensible to me.

### Example

![image](https://user-images.githubusercontent.com/19716675/176244726-07198bb9-c78b-42ac-a67a-53c4f7f9e492.png)
 