### PR TITLE
Make website URL edgesec.info

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   title: "EDGESEC",
   tagline: "Secure IoT router implementation",
-  url: "https://nqminds.github.io",
+  url: "https://edgesec.info",
   baseUrl: "/", // usually your repo name, must contain a trailing and starting slash
   favicon: "img/network.svg",
   organizationName: "nqmcyber", // Usually your GitHub org/user name.

--- a/docusaurus/static/CNAME
+++ b/docusaurus/static/CNAME
@@ -1,0 +1,1 @@
+edgesec.info


### PR DESCRIPTION
We need to put the `CNAME` file into `docusaurus/static`, so that it is always added to the `gh-pages` branch.