### PR TITLE
ci: bump CI Node version to Node v18

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-          node-version: "14.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
           cache: npm
           cache-dependency-path: |


### PR DESCRIPTION
Node v14 was failing to build docusuaurus, since docusaurus needed at least Node v16.