### PR TITLE
chore: update remark-mermaid to v2

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -16,7 +16,7 @@
         "docusaurus-pdf": "^1.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "remark-mermaid-dataurl": "^1.0.2"
+        "remark-mermaid-dataurl": "^2.0.0"
       },
       "devDependencies": {
         "@nqminds/eslint-config-react": "^1.1.0",
@@ -1864,10 +1864,9 @@
       }
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
-      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==",
-      "deprecated": "Potential XSS vulnerability patched in v6.0.0."
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -2823,14 +2822,14 @@
       }
     },
     "node_modules/@mermaid-js/mermaid-cli": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-8.14.0.tgz",
-      "integrity": "sha512-NHuFVPINakXJlAX0DHl3Bvcrz664ZblHfvB7M2X9fwTZNMZzoFTO2k0Q79Rh9QTmZTmmMjj0JmKMg7LiP+pFCA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-9.1.3.tgz",
+      "integrity": "sha512-R7VFArRIhczOejWtKT2Ii8MVKayjpiY6hebGqtcmA8FGSUXDgB4QzK5z9zpOfh1k90XH0PzPpTlL4KXnFfDx1Q==",
       "dependencies": {
         "chalk": "^4.1.0",
         "commander": "^9.0.0",
-        "mermaid": "^8.9.0",
-        "puppeteer": "^13.0.0"
+        "mermaid": "^9.0.0",
+        "puppeteer": "^14.1.0"
       },
       "bin": {
         "mmdc": "index.bundle.js"
@@ -2893,9 +2892,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@mermaid-js/mermaid-cli/node_modules/commander": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
-      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -2942,9 +2941,9 @@
       }
     },
     "node_modules/@mermaid-js/mermaid-cli/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -2954,26 +2953,26 @@
       }
     },
     "node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.5.2.tgz",
-      "integrity": "sha512-DJAyXODBikZ3xPs8C35CtExEw78LZR9RyelGDAs0tX1dERv3OfW7qpQ9VPBgsfz+hG2HiMTO/Tyf7BuMVWsrxg==",
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.4.1.tgz",
+      "integrity": "sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.969999",
+        "devtools-protocol": "0.0.1001819",
         "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
+        "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.5.0"
+        "ws": "8.7.0"
       },
       "engines": {
-        "node": ">=10.18.1"
+        "node": ">=14.1.0"
       }
     },
     "node_modules/@mermaid-js/mermaid-cli/node_modules/supports-color": {
@@ -2988,9 +2987,9 @@
       }
     },
     "node_modules/@mermaid-js/mermaid-cli/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6009,16 +6008,16 @@
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/d3": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.4.4.tgz",
-      "integrity": "sha512-97FE+MYdAlV3R9P74+R3Uar7wUKkIFu89UWMjEaDhiJ9VxKvqaMxauImy8PC2DdBkdM2BxJOIoLxPrcZUyrKoQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -6049,9 +6048,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.6.tgz",
-      "integrity": "sha512-DCbBBNuKOeiR9h04ySRBMW52TFVc91O9wJziuyXw6Ztmy8D3oZbmCkOO3UHKC7ceNJsN2Mavo9+vwV8EAEUXzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -6107,11 +6106,11 @@
       }
     },
     "node_modules/d3-contour": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-3.0.1.tgz",
-      "integrity": "sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "dependencies": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       },
       "engines": {
         "node": ">=12"
@@ -6933,9 +6932,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.969999",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.969999.tgz",
-      "integrity": "sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ=="
+      "version": "0.0.1001819",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
+      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ=="
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -7161,9 +7160,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.5.tgz",
-      "integrity": "sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ=="
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -10538,9 +10537,9 @@
       }
     },
     "node_modules/khroma": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.4.1.tgz",
-      "integrity": "sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
+      "integrity": "sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -11163,17 +11162,17 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.14.0.tgz",
-      "integrity": "sha512-ITSHjwVaby1Li738sxhF48sLTxcNyUAoWfoqyztL1f7J6JOLpHOuQPNLBb6lxGPUA0u7xP9IRULgvod0dKu35A==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.1.3.tgz",
+      "integrity": "sha512-jTIYiqKwsUXVCoxHUVkK8t0QN3zSKIdJlb9thT0J5jCnzXyc+gqTbZE2QmjRfavFTPPn5eRy5zaFp7V+6RhxYg==",
       "dependencies": {
-        "@braintree/sanitize-url": "^3.1.0",
+        "@braintree/sanitize-url": "^6.0.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.5",
+        "dompurify": "2.3.8",
         "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
+        "khroma": "^2.0.0",
         "moment-mini": "^2.24.0",
         "stylis": "^4.0.10"
       }
@@ -13764,18 +13763,18 @@
       }
     },
     "node_modules/remark-mermaid-dataurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/remark-mermaid-dataurl/-/remark-mermaid-dataurl-1.1.1.tgz",
-      "integrity": "sha512-r/PQ2LECACVoNJ0Qag2+XIYOwerpyUEEtVFlkObM+zblcXByUa7YaWtA0/swxeeBuJFM+tA8qWMpoeBHyWiMkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-mermaid-dataurl/-/remark-mermaid-dataurl-2.0.0.tgz",
+      "integrity": "sha512-ev/o5XZOZBosXdnNQ0YzxY7Tl3NuGJlvPNenQ5LgkzgfBvdMGG9IjaZU8GN4esDXE8hebwP5yiKmw+8u4PqFMg==",
       "dependencies": {
-        "@mermaid-js/mermaid-cli": "^8.9.2",
+        "@mermaid-js/mermaid-cli": "^9.1.2",
         "@svgdotjs/svg.js": "^3.1.2",
         "memfs": "^3.2.0",
         "svgdom": "^0.1.10",
         "unist-util-visit": "^2.0.3"
       },
       "engines": {
-        "node": "^10.17.0 || >= 11.14.0"
+        "node": ">=14.1.0"
       }
     },
     "node_modules/remark-parse": {
@@ -14056,7 +14055,7 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/rxjs": {
       "version": "7.5.5",
@@ -14878,9 +14877,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.0.tgz",
-      "integrity": "sha512-SrSDzNasOCBTo7C2N9geFwydg/2bmdkWXd4gJirtq82m5JBYtR2+Ialck8czmfBLIdPxCOotlgJESPa8C1RqvA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.1.tgz",
+      "integrity": "sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -18234,9 +18233,9 @@
       }
     },
     "@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
-      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -18966,14 +18965,14 @@
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
     "@mermaid-js/mermaid-cli": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-8.14.0.tgz",
-      "integrity": "sha512-NHuFVPINakXJlAX0DHl3Bvcrz664ZblHfvB7M2X9fwTZNMZzoFTO2k0Q79Rh9QTmZTmmMjj0JmKMg7LiP+pFCA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-9.1.3.tgz",
+      "integrity": "sha512-R7VFArRIhczOejWtKT2Ii8MVKayjpiY6hebGqtcmA8FGSUXDgB4QzK5z9zpOfh1k90XH0PzPpTlL4KXnFfDx1Q==",
       "requires": {
         "chalk": "^4.1.0",
         "commander": "^9.0.0",
-        "mermaid": "^8.9.0",
-        "puppeteer": "^13.0.0"
+        "mermaid": "^9.0.0",
+        "puppeteer": "^14.1.0"
       },
       "dependencies": {
         "agent-base": {
@@ -19015,9 +19014,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
-          "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w=="
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
         },
         "extract-zip": {
           "version": "2.0.1",
@@ -19044,31 +19043,31 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
           "requires": {
             "agent-base": "6",
             "debug": "4"
           }
         },
         "puppeteer": {
-          "version": "13.5.2",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.5.2.tgz",
-          "integrity": "sha512-DJAyXODBikZ3xPs8C35CtExEw78LZR9RyelGDAs0tX1dERv3OfW7qpQ9VPBgsfz+hG2HiMTO/Tyf7BuMVWsrxg==",
+          "version": "14.4.1",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.4.1.tgz",
+          "integrity": "sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==",
           "requires": {
             "cross-fetch": "3.1.5",
             "debug": "4.3.4",
-            "devtools-protocol": "0.0.969999",
+            "devtools-protocol": "0.0.1001819",
             "extract-zip": "2.0.1",
-            "https-proxy-agent": "5.0.0",
+            "https-proxy-agent": "5.0.1",
             "pkg-dir": "4.2.0",
             "progress": "2.0.3",
             "proxy-from-env": "1.1.0",
             "rimraf": "3.0.2",
             "tar-fs": "2.1.1",
             "unbzip2-stream": "1.4.3",
-            "ws": "8.5.0"
+            "ws": "8.7.0"
           }
         },
         "supports-color": {
@@ -19080,9 +19079,9 @@
           }
         },
         "ws": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
           "requires": {}
         }
       }
@@ -21292,16 +21291,16 @@
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "d3": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.4.4.tgz",
-      "integrity": "sha512-97FE+MYdAlV3R9P74+R3Uar7wUKkIFu89UWMjEaDhiJ9VxKvqaMxauImy8PC2DdBkdM2BxJOIoLxPrcZUyrKoQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -21329,9 +21328,9 @@
       }
     },
     "d3-array": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.6.tgz",
-      "integrity": "sha512-DCbBBNuKOeiR9h04ySRBMW52TFVc91O9wJziuyXw6Ztmy8D3oZbmCkOO3UHKC7ceNJsN2Mavo9+vwV8EAEUXzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -21372,11 +21371,11 @@
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-contour": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-3.0.1.tgz",
-      "integrity": "sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
       "requires": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {
@@ -22043,9 +22042,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.969999",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.969999.tgz",
-      "integrity": "sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ=="
+      "version": "0.0.1001819",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
+      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ=="
     },
     "dfa": {
       "version": "1.2.0",
@@ -22209,9 +22208,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.5.tgz",
-      "integrity": "sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ=="
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -24634,9 +24633,9 @@
       }
     },
     "khroma": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.4.1.tgz",
-      "integrity": "sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
+      "integrity": "sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -25101,17 +25100,17 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "mermaid": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.14.0.tgz",
-      "integrity": "sha512-ITSHjwVaby1Li738sxhF48sLTxcNyUAoWfoqyztL1f7J6JOLpHOuQPNLBb6lxGPUA0u7xP9IRULgvod0dKu35A==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.1.3.tgz",
+      "integrity": "sha512-jTIYiqKwsUXVCoxHUVkK8t0QN3zSKIdJlb9thT0J5jCnzXyc+gqTbZE2QmjRfavFTPPn5eRy5zaFp7V+6RhxYg==",
       "requires": {
-        "@braintree/sanitize-url": "^3.1.0",
+        "@braintree/sanitize-url": "^6.0.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.5",
+        "dompurify": "2.3.8",
         "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
+        "khroma": "^2.0.0",
         "moment-mini": "^2.24.0",
         "stylis": "^4.0.10"
       }
@@ -26943,11 +26942,11 @@
       }
     },
     "remark-mermaid-dataurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/remark-mermaid-dataurl/-/remark-mermaid-dataurl-1.1.1.tgz",
-      "integrity": "sha512-r/PQ2LECACVoNJ0Qag2+XIYOwerpyUEEtVFlkObM+zblcXByUa7YaWtA0/swxeeBuJFM+tA8qWMpoeBHyWiMkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-mermaid-dataurl/-/remark-mermaid-dataurl-2.0.0.tgz",
+      "integrity": "sha512-ev/o5XZOZBosXdnNQ0YzxY7Tl3NuGJlvPNenQ5LgkzgfBvdMGG9IjaZU8GN4esDXE8hebwP5yiKmw+8u4PqFMg==",
       "requires": {
-        "@mermaid-js/mermaid-cli": "^8.9.2",
+        "@mermaid-js/mermaid-cli": "^9.1.2",
         "@svgdotjs/svg.js": "^3.1.2",
         "memfs": "^3.2.0",
         "svgdom": "^0.1.10",
@@ -27151,7 +27150,7 @@
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "rxjs": {
       "version": "7.5.5",
@@ -27797,9 +27796,9 @@
       }
     },
     "stylis": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.0.tgz",
-      "integrity": "sha512-SrSDzNasOCBTo7C2N9geFwydg/2bmdkWXd4gJirtq82m5JBYtR2+Ialck8czmfBLIdPxCOotlgJESPa8C1RqvA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.1.tgz",
+      "integrity": "sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -22,7 +22,7 @@
     "docusaurus-pdf": "^1.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remark-mermaid-dataurl": "^1.0.2"
+    "remark-mermaid-dataurl": "^2.0.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Fixes two potential security vulnerabilities according to dependabot.

To be honest, I'm not even sure if we're using any:

```mermaid
graph TD;
    Example-->Mermaid;
    Mermaid-->Diagram;
```

but it might be worth keeping it anyway, just in case we want to add any in the future.