### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should allow automatically updating NPM packages ASAP on the website to avoid those GitHub security vulnerabilities warnings that @mereacre doesn't like.

I'm adding in @cbrafter too as a reviewer, since although this PR is for an static website hosted on GitHub Pages (so not really any large risk of security issues), having a dependabot config makes sense for any app that has CI & CD, since that way databots will be quickly updated automatically (unfortunately, it only works with `npm`/`yarn`, not `lerna`).

It needs both CI (so that we can test the apps/databots work before merging) and CD (so the apps/databots get auto-deployed), otherwise this isn't useful though.