### PR TITLE
ci: run lint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install modules (CI-mode)
         run: npm ci
+        
+      - name: Lint
+        run: npm run lint
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Add a CI action that checks whether linting works properly.

Needed to make sure PRs like https://github.com/nqminds/edgesec.info/pull/12 work properly.