### PR TITLE
ci(docs): use new github-pages CI action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,14 +32,25 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: publish docs (main-branch only)
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload docs
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
-          enable_jekyll: false
-          allow_empty_commit: false
-          force_orphan: true
-          publish_branch: gh-pages
+          path: ./build
+  deploy-docs:
+    name: publish docs (main-branch only)
+    if: github.ref == 'refs/heads/main'
+    needs: build-docs
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
GitHub Pages now accepts being deployed directly from GitHub Actions, so we no longer need a `gh-pages` branch.

See https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/