### PR TITLE
chore!: drop Node.JS v14 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
         "prettier": "^2.8.8"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >= 20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "lint": "eslint *.js src/ && npx prettier . --check",
     "prepare": "husky install"
   },
+  "engines": {
+    "node": "^16 || ^18 || >= 20.0.0"
+  },
   "dependencies": {
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",


### PR DESCRIPTION
Node.JS v14 is no longer supported, and we need to drop support for it in order to support new versions of packages.

This is needed to merge PR #163.

---

Side-note, I really want to drop Node.JS v16 support too, but unfortunately, we're blocked by our `@nqminds/eslint-config` plugin, see https://github.com/nqminds/nqm-utils/issues/229, which we really need to fix at some point.